### PR TITLE
Create .editorconfig so that compatible editors (neovim) use 2 spaces.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+
+# Indentation override for all JS/TS files
+[*.{js,jsx,ts,tsx}]
+indent_style = space
+charset = utf-8
+indent_size = 2
+


### PR DESCRIPTION
My default setup of neovim is for four spaces.  This file will change the editor to use 2 spaces when editing js(x) and ts(x) files within the template.

Refer to https://editorconfig.org